### PR TITLE
Update model.c

### DIFF
--- a/src/models/model.c
+++ b/src/models/model.c
@@ -1592,9 +1592,9 @@ MODEL m_fic_va503p = {"[Super 7] FIC VA-503+",
                       "fic_va503p",
                       {{"Intel", cpus_Pentium}, {"AMD", cpus_K6_SS7}, {"IDT", cpus_WinChip_SS7}, {"Cyrix", cpus_6x86_SS7}},
                       MODEL_GFX_NONE | MODEL_AT | MODEL_PCI | MODEL_PS2 | MODEL_HAS_IDE,
-                      1,
+                      8,
                       512,
-                      1,
+                      8,
                       at_mvp3_init,
                       NULL};
 
@@ -1744,3 +1744,4 @@ void model_init_builtin() {
         /* Slot 1 PC's */
         pcem_add_model(&m_ga686bx);
 }
+


### PR DESCRIPTION
FIC-VA 503+ minimum RAM should be 8MB

With only 1MB it can't even load the BIOS SETUP, with 2 to 7MB it seems to work, but the user manual says the minimum is 2x4MB SIMM modules or 1x8MB DIMM module.